### PR TITLE
Add align right and align bottom settings

### DIFF
--- a/app/src/main/java/com/ms_square/android/design/overlay/service/DesignOverlayService.java
+++ b/app/src/main/java/com/ms_square/android/design/overlay/service/DesignOverlayService.java
@@ -173,7 +173,10 @@ public class DesignOverlayService extends Service {
 
     private void updateGridSize() {
         if (mGridView != null) {
-            mGridView.updateGridSize(PrefUtil.getGridSize(DesignOverlayService.this));
+            final int gridSize = PrefUtil.getGridSize(DesignOverlayService.this);
+            final boolean alignRight = PrefUtil.isAlignRight(DesignOverlayService.this);
+            final boolean alignBottom = PrefUtil.isAlignBottom(DesignOverlayService.this);
+            mGridView.updateGridSize(gridSize, alignRight, alignBottom);
         }
     }
 
@@ -258,6 +261,14 @@ public class DesignOverlayService extends Service {
                     break;
                 }
                 case PrefUtil.PREF_GRID_SIZE: {
+                    updateGridSize();
+                    break;
+                }
+                case PrefUtil.PREF_ALIGN_RIGHT: {
+                    updateGridSize();
+                    break;
+                }
+                case PrefUtil.PREF_ALIGN_BOTTOM: {
                     updateGridSize();
                     break;
                 }

--- a/app/src/main/java/com/ms_square/android/design/overlay/util/PrefUtil.java
+++ b/app/src/main/java/com/ms_square/android/design/overlay/util/PrefUtil.java
@@ -19,6 +19,10 @@ public class PrefUtil {
 
     public static final String PREF_GRID_ENABLED = "pref_grid_enabled";
 
+    public static final String PREF_ALIGN_RIGHT = "pref_align_right";
+
+    public static final String PREF_ALIGN_BOTTOM = "pref_align_bottom";
+
     public static final String PREF_GRID_SIZE = "pref_grid_size";
 
     public static final String PREF_GRID_COLOR = "pref_grid_color";
@@ -63,6 +67,14 @@ public class PrefUtil {
     public static int getGridSize(Context context) {
         return (int) DimenUtil.convertToPixelFromDip(context,
                 Float.parseFloat(getSharedPrefs(context).getString(PREF_GRID_SIZE, "4")));
+    }
+
+    public static boolean isAlignRight(Context context) {
+        return getSharedPrefs(context).getBoolean(PREF_ALIGN_RIGHT, false);
+    }
+
+    public static boolean isAlignBottom(Context context) {
+        return getSharedPrefs(context).getBoolean(PREF_ALIGN_BOTTOM, false);
     }
 
     public static int getGridColor(Context context) {

--- a/app/src/main/java/com/ms_square/android/design/overlay/view/GridView.java
+++ b/app/src/main/java/com/ms_square/android/design/overlay/view/GridView.java
@@ -19,6 +19,8 @@ public class GridView extends View {
     private int mGridSize;
 
     private float[] mPoints;
+    private boolean mAlignBottom;
+    private boolean mAlignRight;
 
     public GridView(Context context) {
         this(context, null);
@@ -45,9 +47,12 @@ public class GridView extends View {
      *
      * @param newGridSize - in pixels
      */
-    public void updateGridSize(int newGridSize) {
+    public void updateGridSize(int newGridSize, boolean alignRight, boolean alignBottom) {
         mGridSize = newGridSize;
-        updateGrid(getWidth(), getHeight(),true,true);
+        mAlignRight = alignRight;
+        mAlignBottom = alignBottom;
+
+        updateGrid(getWidth(), getHeight());
         invalidate();
     }
 
@@ -56,7 +61,7 @@ public class GridView extends View {
         invalidate();
     }
 
-    private void updateGrid(int width, int height, boolean alignRight, boolean alignBottom) {
+    private void updateGrid(int width, int height) {
         int numHorizontalLines = height / mGridSize;
         int numVerticalLines = width / mGridSize;
 
@@ -67,7 +72,7 @@ public class GridView extends View {
             mPoints = new float[numHorizontalPoints + numVerticalPoints];
 
             int positionShift = 0;
-            if (alignRight) {
+            if (mAlignBottom) {
                 positionShift = - (mGridSize - height % mGridSize);
             }
 
@@ -83,7 +88,7 @@ public class GridView extends View {
             }
 
             positionShift = 0;
-            if (alignBottom) {
+            if (mAlignRight) {
                 positionShift = - (mGridSize - width % mGridSize);
             }
 
@@ -106,7 +111,7 @@ public class GridView extends View {
     protected void onSizeChanged(int w, int h, int oldw, int oldh) {
         super.onSizeChanged(w, h, oldw, oldh);
         Timber.d("SizeChanged: %d, %d, %d, %d", w, h, oldw, oldh);
-        updateGrid(w, h,true,true);
+        updateGrid(w, h);
     }
 
     @Override

--- a/app/src/main/java/com/ms_square/android/design/overlay/view/GridView.java
+++ b/app/src/main/java/com/ms_square/android/design/overlay/view/GridView.java
@@ -47,7 +47,7 @@ public class GridView extends View {
      */
     public void updateGridSize(int newGridSize) {
         mGridSize = newGridSize;
-        updateGrid(getWidth(), getHeight());
+        updateGrid(getWidth(), getHeight(),true,true);
         invalidate();
     }
 
@@ -56,7 +56,7 @@ public class GridView extends View {
         invalidate();
     }
 
-    private void updateGrid(int width, int height) {
+    private void updateGrid(int width, int height, boolean alignRight, boolean alignBottom) {
         int numHorizontalLines = height / mGridSize;
         int numVerticalLines = width / mGridSize;
 
@@ -66,24 +66,34 @@ public class GridView extends View {
         if (numHorizontalPoints + numVerticalPoints > 0) {
             mPoints = new float[numHorizontalPoints + numVerticalPoints];
 
+            int positionShift = 0;
+            if (alignRight) {
+                positionShift = - (mGridSize - height % mGridSize);
+            }
+
             // set up horizontal lines
             float gap = mGridSize;
             for (int i = 0; i <= numHorizontalLines; i++) {
                 int base = i * 4;
                 mPoints[base] = 0f;
-                mPoints[base + 1] = gap;
+                mPoints[base + 1] = gap + positionShift;
                 mPoints[base + 2] = (float) width;
-                mPoints[base + 3] = gap;
+                mPoints[base + 3] = gap + positionShift;
                 gap = gap + mGridSize;
+            }
+
+            positionShift = 0;
+            if (alignBottom) {
+                positionShift = - (mGridSize - width % mGridSize);
             }
 
             // set up vertical lines
             gap = mGridSize;
             for (int i = 0; i <= numVerticalLines; i++) {
                 int base = i * 4 + numHorizontalPoints;
-                mPoints[base] = gap;
+                mPoints[base] = gap + positionShift;
                 mPoints[base + 1] = 0f;
-                mPoints[base + 2] = gap;
+                mPoints[base + 2] = gap + positionShift;
                 mPoints[base + 3] = (float) height;
                 gap = gap + mGridSize;
             }
@@ -96,7 +106,7 @@ public class GridView extends View {
     protected void onSizeChanged(int w, int h, int oldw, int oldh) {
         super.onSizeChanged(w, h, oldw, oldh);
         Timber.d("SizeChanged: %d, %d, %d, %d", w, h, oldw, oldh);
-        updateGrid(w, h);
+        updateGrid(w, h,true,true);
     }
 
     @Override

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -23,6 +23,10 @@
     <string name="pref_grid_enabled_title">表示</string>
     <string name="pref_grid_size_title">サイズ</string>
     <string name="pref_grid_size_summary">サイズ: %1$s dp</string>
+
+    <string name="pref_align_right_title">右に揃える</string>
+    <string name="pref_align_bottom_title">下に揃える</string>
+
     <string name="pref_grid_color_title">色</string>
     <string name="pref_grid_color_summary">グリッド線の色を選択</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,8 @@
     <string name="pref_grid_enabled_title">Enabled</string>
     <string name="pref_grid_size_title">Size</string>
     <string name="pref_grid_size_summary">Size: %1$s dp</string>
+    <string name="pref_align_right_title">Align right</string>
+    <string name="pref_align_bottom_title">Align bottom</string>
     <string name="pref_grid_color_title">Color</string>
     <string name="pref_grid_color_summary">Choose grid line color</string>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -29,6 +29,14 @@
             android:entries="@array/grid_size_entries"
             android:entryValues="@array/grid_size_entry_values"
             android:defaultValue="4"/>
+        <CheckBoxPreference
+            android:key="pref_align_right"
+            android:defaultValue="false"
+            android:title="@string/pref_align_right_title" />
+        <CheckBoxPreference
+            android:key="pref_align_bottom"
+            android:defaultValue="false"
+            android:title="@string/pref_align_bottom_title" />
         <net.margaritov.preference.colorpicker.ColorPickerPreference
             android:key="pref_grid_color"
             android:title="@string/pref_grid_color_title"


### PR DESCRIPTION
Add grid align settings.
It is useful for checking right margin and bottom margin.

| none | align right | align bottom | both |
| --- | --- | --- | --- |
| ![screenshot_20160108_014341](https://cloud.githubusercontent.com/assets/1386930/12176194/8d97ec3e-b5a9-11e5-9900-f09e918baa88.png) | ![screenshot_20160108_014350](https://cloud.githubusercontent.com/assets/1386930/12176155/61cfd36e-b5a9-11e5-94f2-cb879dab24d5.png) | ![screenshot_20160108_014358](https://cloud.githubusercontent.com/assets/1386930/12176161/63cb009e-b5a9-11e5-9c1e-87e2495c179a.png) | ![screenshot_20160108_014406](https://cloud.githubusercontent.com/assets/1386930/12176165/65339cca-b5a9-11e5-88e1-18f2b23173c6.png) |
